### PR TITLE
add the setter to several properties of beamline objects

### DIFF
--- a/src/ari_sxn_simbeamline/xrt_sim/custom_devices.py
+++ b/src/ari_sxn_simbeamline/xrt_sim/custom_devices.py
@@ -84,6 +84,11 @@ class TestM1(TestMirror):
         calculated_Ry = self.Ry_coarse + self.Ry_fine
         return calculated_Ry
 
+    @Ry.setter
+    def Ry(self, set_point): # function used to take input from command line
+        self.Ry_fine = set_point
+        self.Ry_coarse = 0 # Make sure the Ry is the total value
+
 
 # Transformation of coordinates between XRT and NSLS-II.
 transform_NSLS2XRT = {'inboard': np.array([[0, -1.0, 0], [0, 0, 1.0],
@@ -268,6 +273,10 @@ class ID29Source(xrt_source.GeometricSource):
         """
         return _parse_parameter_map(self._default_parameter_map)
 
+    @_parameter_map.setter
+    def _parameter_map(self, new_parameter_map): # used to take input manually
+        self._default_parameter_map = new_parameter_map
+
     def activate(self, updated=False):
         """
         A method adding or modifying the beamOut attribute.
@@ -401,6 +410,10 @@ class ID29OE(xrt_oes.OE):
         """
         return _parse_parameter_map(self._default_parameter_map)
 
+    @_parameter_map.setter
+    def _parameter_map(self, new_parameter_map): # used to take input manually
+        self._default_parameter_map = new_parameter_map
+
     def activate(self, updated=False):
         """
         A method adding or modifying the beamOut attribute.
@@ -532,6 +545,10 @@ class ID29Aperture(xrt_aperture.RectangularAperture):
         """
         return _parse_parameter_map(self._default_parameter_map)
 
+    @_parameter_map.setter
+    def _parameter_map(self, new_parameter_map): # used to take input manually
+        self._default_parameter_map = new_parameter_map
+
     def activate(self, updated=False):
         """
         A method adding or modifying the beamOut attribute.
@@ -662,6 +679,10 @@ class ID29Screen(xrt_screen.Screen):
         An attribute-like method that returns an updated parameter_map.
         """
         return _parse_parameter_map(self._default_parameter_map)
+
+    @_parameter_map.setter
+    def _parameter_map(self, new_parameter_map): # used to take input manually
+        self._default_parameter_map = new_parameter_map
 
     def activate(self, updated=False):
         """

--- a/src/ari_sxn_simbeamline/xrt_sim/custom_devices.py
+++ b/src/ari_sxn_simbeamline/xrt_sim/custom_devices.py
@@ -86,8 +86,10 @@ class TestM1(TestMirror):
 
     @Ry.setter
     def Ry(self, set_point): # function used to take input from command line
-        self.Ry_fine = set_point
-        self.Ry_coarse = 0 # Make sure the Ry is the total value
+
+        raise ValueError('Ry is read only and can only be reset through '
+                         'Ry_coarse and Ry_fine!')
+
 
 
 # Transformation of coordinates between XRT and NSLS-II.
@@ -275,7 +277,8 @@ class ID29Source(xrt_source.GeometricSource):
 
     @_parameter_map.setter
     def _parameter_map(self, new_parameter_map): # used to take input manually
-        self._default_parameter_map = new_parameter_map
+
+        raise ValueError('The _parameter_map can not be reset!')
 
     def activate(self, updated=False):
         """
@@ -412,7 +415,8 @@ class ID29OE(xrt_oes.OE):
 
     @_parameter_map.setter
     def _parameter_map(self, new_parameter_map): # used to take input manually
-        self._default_parameter_map = new_parameter_map
+
+        raise ValueError('The _parameter_map can not be reset!')
 
     def activate(self, updated=False):
         """
@@ -547,7 +551,7 @@ class ID29Aperture(xrt_aperture.RectangularAperture):
 
     @_parameter_map.setter
     def _parameter_map(self, new_parameter_map): # used to take input manually
-        self._default_parameter_map = new_parameter_map
+        raise ValueError('The _parameter_map can not be reset!')
 
     def activate(self, updated=False):
         """
@@ -682,7 +686,7 @@ class ID29Screen(xrt_screen.Screen):
 
     @_parameter_map.setter
     def _parameter_map(self, new_parameter_map): # used to take input manually
-        self._default_parameter_map = new_parameter_map
+        raise ValueError('The _parameter_map can not be reset!')
 
     def activate(self, updated=False):
         """


### PR DESCRIPTION
@awalter-bnl  Please review the changes I made, especially those ones for the Ry in TestM1 as it contains two independent parameters (Ry_coarse and Ry_fine)